### PR TITLE
Prevent loop in binary detection logic when calling ssh-ident directly

### DIFF
--- a/ssh-ident
+++ b/ssh-ident
@@ -1425,7 +1425,7 @@ def main(argv):
   # Autodetect BINARY_SSH.
   # Either explicitily defined, ssh-ident as wrapper or fallback to ssh.
   binary_checks = {
-    "BINARY_SSH": [os.path.basename(argv[0]), 'ssh', ],
+    "BINARY_SSH": ['ssh', ],
   }
   AutodetectBinary(argv[0], config, binary_checks)
   del binary_checks


### PR DESCRIPTION
Without this patch the following invocation fails:

$ ./ssh-ident fab
[ERROR] ssh-ident found 'ssh-ident' as the next command to run. Based on argv[0] (./ssh-ident), it seems like this will create a loop.

Please use BINARY_DIR, or BINARY_SSH plus BINARY_SSH_AGENT plus BINARY_SSH_ADD, or change the way ssh-ident is invoked (eg, a different argv[0]) to makeit work correctly.